### PR TITLE
Bugfix: Fixing inappropriate ordering of naming strategies

### DIFF
--- a/classes/parsers/RDFIO_URIToWikiTitleConverter.php
+++ b/classes/parsers/RDFIO_URIToWikiTitleConverter.php
@@ -42,8 +42,8 @@ class RDFIOURIToTitleConverter {
 		// You'll find them defined further below in this file.
 		$uriToWikiTitleConversionStrategies = array(
 			'getExistingTitleForURI',
-			'applyGlobalSettingForPropertiesToUseAsWikiTitle',
 			'shortenURINamespaceToAliasInSourceRDF',
+			'applyGlobalSettingForPropertiesToUseAsWikiTitle',
 			'extractLocalPartFromURI'
 		);
 


### PR DESCRIPTION
This re-ordering of naming strategies fixes a failing unit test, and is how the naming was originally intended to be done.
